### PR TITLE
Projects with multiple dependencies now cannot cause name collision

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 
 var verbose = false;
+var dependencies = false;
 var assets = [];
 
 module.exports = {
@@ -31,6 +32,10 @@ function load(config) {
 
     if (config && config.debug) {
         verbose = true;
+    }
+
+    if (config.dependencies) {
+        dependencies = true;
     }
 
     var cwd = process.cwd();
@@ -56,7 +61,7 @@ function processPkg(curDir) {
         }
     }
 
-    if (!meta || !meta.dependencies) {
+    if (!meta || !meta.dependencies || !meta.assets) {
         return;
     }
 
@@ -82,7 +87,14 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         gutil.log(LOG_ID, gutil.colors.green('found assets in ', pkgName, pkgAssets));
     }
 
-    if (Array.isArray(pkgAssets)) {
+    if (dependencies) {
+
+        assets.push({
+            name: pkgName,
+            assets: pkgAssets
+        });
+
+    } else if (Array.isArray(pkgAssets)) {
         pkgAssets.forEach(assetPush);
     } else {
         assetPush(pkgAssets);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function processPkg(curDir) {
         }
     }
 
-    if (!meta || !meta.dependencies || !meta.assets) {
+    if (!meta || !meta.dependencies) {
         return;
     }
 
@@ -75,17 +75,11 @@ function processPkg(curDir) {
 function grabAssets(pkgName, basePath, pkgAssets) {
 
     if (!pkgAssets || !basePath) {
-        if (verbose) {
-            gutil.log(LOG_ID, gutil.colors.yellow('no assets found in ', basePath));
-        } else {
-            gutil.log(LOG_ID, gutil.colors.yellow('no assets found in ', pkgName));
-        }
         return;
     }
 
-    if (verbose) {
-        gutil.log(LOG_ID, gutil.colors.green('found assets in ', pkgName, pkgAssets));
-    }
+    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
+    '\nassets:', pkgAssets));
 
     if (dependencies) {
 

--- a/index.js
+++ b/index.js
@@ -78,8 +78,10 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         return;
     }
 
-    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
-    '\nassets:', pkgAssets));
+    if (verbose) {
+        gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
+        '\nassets:', pkgAssets));
+    }
 
     if (dependencies) {
 


### PR DESCRIPTION
When loading the assets you can now pass an argument called dependencies that returns an array of objects with package name and the assets paths.

Output example:
`[{
    name: package-name,
    assets: ['path1', 'path2']
}];`


This way when piping the data to gulp you can create a dir for each project like this:
`assets.forEach(function(asset) {
        gulp.src(asset.assets).pipe(gulp.dest('build/assets/' + asset.name));
});`