### PR TITLE
Introduced switch for when projects has multiple asset sources avoiding name collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Let's say you have a package named `my-site`, which contains some assets and npm
 }
 ```
 
-You could retreive all your project assets with:
+You could retrieve all your project assets with:
 
 ```js
 var assets = require('find-npm-assets').load();
@@ -43,7 +43,7 @@ var assets = require('find-npm-assets').load();
 ## Gulp usage
 
 Integrating find-npm-assets with gulp is extremely easy. The following gulp task copies all your project assets to a destination folder:
- 
+
 ```js
 var assets = require('find-npm-assets').load();
 
@@ -52,6 +52,24 @@ gulp.task('assets', function() {
         .pipe(gulp.dest('build/assets'))
 });
 
+```
+
+For projects with assets coming from multiple packages it is recommended to use the `verticalDirStructure` switch, which organizes assets by project name:
+
+```js
+var assets = require('find-npm-assets').load({verticalDirStructure: true});
+
+gulp.task('assets', function() {
+    assets.forEach(function(pkg){
+        gulp.src(pkg.asset).pipe(gulp.dest('build/assets/' + pkg.name));
+    });
+})
+
+// Example output:
+// {
+// name: projectName
+// assets: ["src/app/assets/**/*", "logo.png", "background.jpg"]
+// }
 ```
 
 ## Reference
@@ -63,7 +81,7 @@ var assetFind = require('find-npm-assets');
 assetFind.load({debug: true});
 ```
 
-You can run `find-npm-assets` from the command line, the `-v` argument will trigger debug information.
+You can run `find-npm-assets` from the command line, the `-v` argument will trigger debug information and `-m` will trigger the `verticalDirStructure` option.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ var assets = require('find-npm-assets').load({verticalDirStructure: true});
 
 gulp.task('assets', function() {
     assets.forEach(function(pkg){
-        gulp.src(pkg.asset).pipe(gulp.dest('build/assets/' + pkg.name));
+        gulp.src(pkg.assets).pipe(gulp.dest('build/assets/' + pkg.name));
     });
 })
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,10 @@ gulp.task('assets', function() {
 
 ```
 
-For projects with assets coming from multiple packages it is recommended to use the `verticalDirStructure` switch, which organizes assets by project name:
+For projects with assets coming from multiple packages it is recommended to set the `pkgDir` property, which allows assets to be organized by project name:
 
 ```js
-var assets = require('find-npm-assets').load({verticalDirStructure: true});
+var assets = require('find-npm-assets').load({pkgDir: true});
 
 gulp.task('assets', function() {
     assets.forEach(function(pkg){
@@ -66,10 +66,14 @@ gulp.task('assets', function() {
 })
 
 // Example output:
-// {
-// name: projectName
-// assets: ["src/app/assets/**/*", "logo.png", "background.jpg"]
-// }
+// [{
+//  name: project1,
+//  assets: ["src/app/assets/**/*", "logo.png", "background.jpg"]
+// }, {
+//  name: project2,
+//  assets: ["src/app/assets/**/*", "logo.png", "background.jpg"]
+// }]
+
 ```
 
 ## Reference
@@ -81,7 +85,7 @@ var assetFind = require('find-npm-assets');
 assetFind.load({debug: true});
 ```
 
-You can run `find-npm-assets` from the command line, the `-v` argument will trigger debug information and `-m` will trigger the `verticalDirStructure` option.
+You can run `find-npm-assets` from the command line, the `-v` argument will trigger debug information and `-m` will trigger the `pkgDir` option.
 
 
 ## License

--- a/index.js
+++ b/index.js
@@ -17,13 +17,17 @@ module.exports = {
 };
 
 if (require.main === module) {
-    if (process.argv[2] === '-v') {
-        verbose = true;
-    }
 
-    if (process.argv[3] === '-m') {
-        verticalDirStructure = true;
-    }
+    process.argv.forEach(function(arg) {
+
+        if (arg === '-v') {
+            verbose = true;
+        }
+
+        if (arg === '-m') {
+            verticalDirStructure = true;
+        }
+    });
 
     load();
 }
@@ -96,7 +100,9 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         assetPush(pkgAssets);
     }
 
-    assets.push(pkgObject);
+    if (verticalDirStructure) {
+        assets.push(pkgObject);
+    }
 
     function assetPush(asset) {
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 
 var verbose = false;
-var dependencies = false;
+var verticalDirStructure = false;
 var assets = [];
 
 module.exports = {
@@ -19,6 +19,10 @@ module.exports = {
 if (require.main === module) {
     if (process.argv[2] === '-v') {
         verbose = true;
+    }
+
+    if (process.argv[3] === '-m') {
+        verticalDirStructure = true;
     }
 
     load();
@@ -34,8 +38,8 @@ function load(config) {
         verbose = true;
     }
 
-    if (config.dependencies) {
-        dependencies = true;
+    if (config && config.verticalDirStructure) {
+        verticalDirStructure = true;
     }
 
     var cwd = process.cwd();
@@ -78,26 +82,29 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         return;
     }
 
-    if (verbose) {
-        gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
+    var pkgObject = {
+        name: pkgName,
+        assets: []
+    };
+
+    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
         '\nassets:', pkgAssets));
-    }
 
-    if (dependencies) {
-
-        assets.push({
-            name: pkgName,
-            assets: pkgAssets
-        });
-
-    } else if (Array.isArray(pkgAssets)) {
+    if (Array.isArray(pkgAssets)) {
         pkgAssets.forEach(assetPush);
     } else {
         assetPush(pkgAssets);
     }
 
-    function assetPush(asset) {
-        assets.push(path.join(basePath, asset));
-    }
+    assets.push(pkgObject);
 
+    function assetPush(asset) {
+
+        if (verticalDirStructure) {
+            pkgObject.assets.push(path.join(basePath, asset));
+        } else {
+            assets.push(path.join(basePath, asset));
+        }
+
+    }
 }

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 
 var verbose = false;
+var dependencies = false;
 var assets = [];
 
 module.exports = {
@@ -31,6 +32,10 @@ function load(config) {
 
     if (config && config.debug) {
         verbose = true;
+    }
+
+    if (config.dependencies) {
+        dependencies = true;
     }
 
     var cwd = process.cwd();
@@ -56,7 +61,7 @@ function processPkg(curDir) {
         }
     }
 
-    if (!meta || !meta.dependencies) {
+    if (!meta || !meta.dependencies || !meta.assets) {
         return;
     }
 
@@ -82,7 +87,14 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         gutil.log(LOG_ID, gutil.colors.green('found assets in ', pkgName, pkgAssets));
     }
 
-    if (Array.isArray(pkgAssets)) {
+    if (dependencies) {
+
+        assets.push({
+            name: pkgName,
+            assets: pkgAssets
+        });
+
+    } else if (Array.isArray(pkgAssets)) {
         pkgAssets.forEach(assetPush);
     } else {
         assetPush(pkgAssets);

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ function processPkg(curDir) {
         }
     }
 
-    if (!meta || !meta.dependencies || !meta.assets) {
+    if (!meta || !meta.dependencies) {
         return;
     }
 
@@ -75,17 +75,11 @@ function processPkg(curDir) {
 function grabAssets(pkgName, basePath, pkgAssets) {
 
     if (!pkgAssets || !basePath) {
-        if (verbose) {
-            gutil.log(LOG_ID, gutil.colors.yellow('no assets found in ', basePath));
-        } else {
-            gutil.log(LOG_ID, gutil.colors.yellow('no assets found in ', pkgName));
-        }
         return;
     }
 
-    if (verbose) {
-        gutil.log(LOG_ID, gutil.colors.green('found assets in ', pkgName, pkgAssets));
-    }
+    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
+    '\nassets:', pkgAssets));
 
     if (dependencies) {
 

--- a/index.js
+++ b/index.js
@@ -78,8 +78,10 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         return;
     }
 
-    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
-    '\nassets:', pkgAssets));
+    if (verbose) {
+        gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
+        '\nassets:', pkgAssets));
+    }
 
     if (dependencies) {
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var path = require('path');
 var gutil = require('gulp-util');
 
 var verbose = false;
-var verticalDirStructure = false;
+var pkgDir = false;
 var assets = [];
 
 module.exports = {
@@ -25,7 +25,7 @@ if (require.main === module) {
         }
 
         if (arg === '-m') {
-            verticalDirStructure = true;
+            pkgDir = true;
         }
     });
 
@@ -42,8 +42,8 @@ function load(config) {
         verbose = true;
     }
 
-    if (config && config.verticalDirStructure) {
-        verticalDirStructure = true;
+    if (config && config.pkgDir) {
+        pkgDir = true;
     }
 
     var cwd = process.cwd();
@@ -83,6 +83,11 @@ function processPkg(curDir) {
 function grabAssets(pkgName, basePath, pkgAssets) {
 
     if (!pkgAssets || !basePath) {
+
+        if (verbose) {
+            gutil.log(LOG_ID, gutil.colors.yellow('no assets found in ', basePath));
+        }
+
         return;
     }
 
@@ -91,8 +96,8 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         assets: []
     };
 
-    gutil.log(LOG_ID, gutil.colors.green('found assets in package:', pkgName,
-        '\nassets:', pkgAssets));
+    gutil.log(LOG_ID, gutil.colors.green('found assets in', pkgName,
+        ':', pkgAssets));
 
     if (Array.isArray(pkgAssets)) {
         pkgAssets.forEach(assetPush);
@@ -100,13 +105,13 @@ function grabAssets(pkgName, basePath, pkgAssets) {
         assetPush(pkgAssets);
     }
 
-    if (verticalDirStructure) {
+    if (pkgDir) {
         assets.push(pkgObject);
     }
 
     function assetPush(asset) {
 
-        if (verticalDirStructure) {
+        if (pkgDir) {
             pkgObject.assets.push(path.join(basePath, asset));
         } else {
             assets.push(path.join(basePath, asset));


### PR DESCRIPTION
Introduced the verticalDirStructure that instead of returning an array of globs, returns an arrays of objects, each object composed by 2 properties: name (package-name) and assets (an arrays of globs).
Getting the output in this state allows you mold your gulp piping to have a different dir for each project avoiding name collision.
Also updated the documentation to support this change.